### PR TITLE
adding (set-endpoint [cred endpoint] ...) for setting of default region

### DIFF
--- a/src/rotary/client.clj
+++ b/src/rotary/client.clj
@@ -58,6 +58,11 @@
     (.setReadCapacityUnits (long read-units))
     (.setWriteCapacityUnits (long write-units))))
 
+(defn set-endpoint [cred endpoint]
+  (.setEndpoint
+    (db-client cred)
+		endpoint))
+
 (defn create-table
   "Create a table in DynamoDB with the given map of properties."
   [cred {:keys [name hash-key range-key throughput]}]


### PR DESCRIPTION
``` clojure
;; added the following
(defn set-endpoint [cred endpoint]
    (.setEndpoint
        (db-client cred)
        endpoint))

;; used like this
(set-endpoint cred "http://dynamodb.us-west-1.amazonaws.com/")
```

I wanted to access a db in region us-west-1 (N. California) but couldn't until I set the endpoint as above.

Thanks for the great work btw.
Elie
