### PR TITLE
Query on range-key, limit, count, and consistent read

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following dependency to your Clojure project:
 
     (def aws-credential {:access-key "myAccessKey", :secret-key "mySecretKey"})
     (query aws-credential "MyTable" "somePrimaryKey")
-    (query aws-credential "AnotherTable" 22 {:range-key 13392 :operator "GT" :limit 100 :count true})
+    (query aws-credential "AnotherTable" 22 `(> 13392) {:limit 100 :count true})
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Add the following dependency to your Clojure project:
 
     [rotary "0.2.3"]
 
+## Simple Example
+
+    (def aws-credential {:access-key "myAccessKey", :secret-key "mySecretKey"})
+    (query aws-credential "MyTable" "somePrimaryKey")
+    (query aws-credential "AnotherTable" 22 {:range-key 13392 :operator "GT" :limit 100 :count true})
+
 ## Documentation
 
 * [API Docs](http://weavejester.github.com/rotary)

--- a/src/rotary/client.clj
+++ b/src/rotary/client.clj
@@ -224,12 +224,11 @@
                              (.withComparisonOperator operator)
                              (.withAttributeValueList attribute-list)))))
 
-(defn- resolve-operator
+(defn- normalize-operator [operator]
   "Maps Clojure operators to DynamoDB operators"
-  [operator]
-  (let [operator-map {`> "GT" `>= "GE" `< "LT" `<= "LE" `= "EQ"}
-        resolved-operator (get operator-map operator)]
-    (or resolved-operator operator)))
+  (let [operator-map {:> "GT" :>= "GE" :< "LT" :<= "LE" := "EQ"}
+        op (->> operator name str/upper-case)]
+    (operator-map (keyword op) op)))
 
 (defn- query-request
   "Create a QueryRequest object."
@@ -237,7 +236,7 @@
   (let [qr (QueryRequest. table (to-attr-value hash-key))
         [operator range-key range-end] range-clause]
     (when operator
-      (set-range-condition qr (resolve-operator operator) range-key range-end))
+      (set-range-condition qr (normalize-operator operator) range-key range-end))
     (when order
       (.setScanIndexForward qr (not= order :desc)))
     (when limit


### PR DESCRIPTION
I implemented querying on a DynamoDB table that has a range-key for all supported operators per #3.
I also added support for limit, count, and consistent read.

I wrote 11 tests as well (which can be viewed on my fork) but I didn't include them as they currently involve setting up a table to test against. I'll look into automated setup and teardown of a table (or mocking the Java SDK responses) when I have a chance.
