### PR TITLE
More flexible key support and additional options from SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ pom.xml
 .lein-failures
 .lein-deps-sum
 .lein-env
+.lein-plugins/
 /doc

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ Add the following dependency to your Clojure project:
 ## Simple Example
 
     (def aws-credential {:access-key "myAccessKey", :secret-key "mySecretKey"})
-    (query aws-credential "MyTable" "somePrimaryKey")
-    (query aws-credential "AnotherTable" 22 `(> 13392) {:limit 100 :count true})
+    (get-item aws-credential "MyTable" "somePrimaryKey")
+    (query aws-credential "AnotherTable" 22 `(> 13392) :limit 100 :count true)
+    (update-item aws-credential "MyFavoriteTable" [36 263] {"awesomeness" [:add 20] "updated" [:put 1339529420]})
+    (put-item aws-credential "RandomTable" {"myHashKey" 777 "theRangeKey" 3843 "someOtherAttribute" 33} :return-values "ALL_OLD")
 
 ## Documentation
 

--- a/project.clj
+++ b/project.clj
@@ -2,5 +2,5 @@
   :description "Amazon DynamoDB API"
   :dependencies [[org.clojure/clojure "1.2.1"]
                  [org.clojure/algo.generic "0.1.0"]
-                 [com.amazonaws/aws-java-sdk "1.3.6"]]
+                 [com.amazonaws/aws-java-sdk "1.3.11"]]
   :plugins [[codox "0.6.1"]])

--- a/src/rotary/client.clj
+++ b/src/rotary/client.clj
@@ -6,13 +6,15 @@
            com.amazonaws.services.dynamodb.AmazonDynamoDBClient
            [com.amazonaws.services.dynamodb.model
             AttributeValue
+            AttributeValueUpdate
             Condition
             CreateTableRequest
-            UpdateTableRequest
+            DeleteItemRequest
+            DeleteItemResult
+            DeleteTableRequest
             DescribeTableRequest
             DescribeTableResult
-            DeleteTableRequest
-            DeleteItemRequest
+            ExpectedAttributeValue
             GetItemRequest
             GetItemResult
             Key
@@ -21,9 +23,12 @@
             ProvisionedThroughput
             ProvisionedThroughputDescription
             PutItemRequest
+            PutItemResult
+            QueryRequest
             ResourceNotFoundException
             ScanRequest
-            QueryRequest]))
+            UpdateItemRequest
+            UpdateTableRequest]))
 
 (defn- db-client*
   "Get a AmazonDynamoDBClient instance for the supplied credentials."
@@ -104,14 +109,15 @@
   DescribeTableResult
   (as-map [result]
     (let [table (.getTable result)]
-      {:name          (.getTableName table)
-       :creation-date (.getCreationDateTime table)
-       :item-count    (.getItemCount table)
-       :key-schema    (as-map (.getKeySchema table))
-       :throughput    (as-map (.getProvisionedThroughput table))
-       :status        (-> (.getTableStatus table)
-                          (str/lower-case)
-                          (keyword))})))
+      {:name             (.getTableName table)
+       :creation-date    (.getCreationDateTime table)
+       :item-count       (.getItemCount table)
+       :table-size-bytes (.getTableSizeBytes table)
+       :key-schema       (as-map (.getKeySchema table))
+       :throughput       (as-map (.getProvisionedThroughput table))
+       :status           (-> (.getTableStatus table)
+                             (str/lower-case)
+                             (keyword))})))
 
 (defn describe-table
   "Returns a map describing the table in DynamoDB with the given name, or nil
@@ -150,6 +156,12 @@
       .getTableNames
       seq))
 
+(defn- normalize-operator [operator]
+  "Maps Clojure operators to DynamoDB operators"
+  (let [operator-map {:> "GT" :>= "GE" :< "LT" :<= "LE" := "EQ"}
+        op (->> operator name str/upper-case)]
+    (operator-map (keyword op) op)))
+
 (defn- to-attr-value
   "Convert a value into an AttributeValue object."
   [value]
@@ -157,15 +169,40 @@
    (string? value)
    (doto (AttributeValue.) (.setS value))
    (number? value)
-   (doto (AttributeValue.) (.setN (str value)))))
+   (doto (AttributeValue.) (.setN (str value)))
+   (coll? value)
+   (cond
+    (string? (first value))
+    (doto (AttributeValue.) (.setSS value))
+    (number? (first value))
+    (doto (AttributeValue.) (.setNS (map str value))))))
+
+(defn- to-attr-value-update
+  "Convert an action and a value into an AttributeValueUpdate object."
+  [value-clause]
+  (let [[action value] value-clause]
+    (AttributeValueUpdate. (to-attr-value value) (normalize-operator action))))
 
 (defn- get-value
   "Get the value of an AttributeValue object."
   [attr-value]
   (or (.getS attr-value)
       (.getN attr-value)
-      (.getNS attr-value)
-      (.getSS attr-value)))
+      (if-let [v (.getNS attr-value)] (into #{} v))
+      (if-let [v (.getSS attr-value)] (into #{} v))))
+
+(defn- to-expected-value
+  "Convert a value to an ExpectedValue object. Handles ::exists
+  and ::not-exists specially."
+  [value]
+  (cond (= value ::exists) (ExpectedAttributeValue. true)
+        (= value ::not-exists) (ExpectedAttributeValue. false)
+        :else (if-let [av (to-attr-value value)] (ExpectedAttributeValue. av))))
+
+(defn- to-expected-values
+  [values]
+  (and (seq values)
+       (fmap to-expected-value values)))
 
 (defn- item-map
   "Turn a item in DynamoDB into a Clojure map."
@@ -176,70 +213,144 @@
 (extend-protocol AsMap
   GetItemResult
   (as-map [result]
-    (item-map (.getItem result))))
+    (with-meta
+      (item-map (or (.getItem result) {}))
+      {:consumed-capacity-units (.getConsumedCapacityUnits result)}))
+
+  PutItemResult
+  (as-map [result]
+    (with-meta
+      (item-map (or (.getAttributes result) {}))
+      {:consumed-capacity-units (.getConsumedCapacityUnits result)}))
+
+  DeleteItemResult
+  (as-map [result]
+    (with-meta
+      (item-map (or (.getAttributes result) {}))
+      {:consumed-capacity-units (.getConsumedCapacityUnits result)})))
 
 (defn put-item
-  "Add an item (a Clojure map) to a DynamoDB table."
-  [cred table item]
-  (.putItem
-   (db-client cred)
-   (doto (PutItemRequest.)
-     (.setTableName table)
-     (.setItem (fmap to-attr-value item)))))
+  "Add an item (a Clojure map) to a DynamoDB table.
+  Takes the following options:
+    :expected - a map from attribute name to:
+       :rotary.client/exists - checks if the attribute exists
+       :rotary.client/not-exists - checks if the attribute doesn't exist
+       anything else - checks if the attribute is equal to it
+    :return-values - specify what to return:
+       \"NONE\", \"ALL_OLD\"
+
+  The metadata of the return value contains:
+    :consumed-capacity-units - the consumed capacity units"
+  [cred table item & {:keys [expected return-values]}]
+  (as-map
+   (.putItem
+    (db-client cred)
+    (doto (PutItemRequest.)
+      (.setTableName table)
+      (.setItem (fmap to-attr-value item))
+      (.setExpected (to-expected-values expected))
+      (.setReturnValues (or return-values "NONE"))))))
 
 (defn- item-key
   "Create a Key object from a value."
-  [hash-key]
-  (Key. (to-attr-value hash-key)))
+  ([key]
+     (cond
+      (nil? key) nil
+      (vector? key) (item-key (first key) (second key))
+      :else (item-key key nil)))
+  ([hash-key range-key]
+     (Key. (to-attr-value hash-key)
+           (to-attr-value range-key))))
+
+(defn- decode-key [k]
+  (let [hash (.getHashKeyElement k)
+        range (.getRangeKeyElement k)]
+    (if range
+      [(get-value hash) (get-value range)]
+      (get-value hash))))
+
+(defn update-item
+  "Update an item (a Clojure map) in a DynamoDB table.
+
+  The key can be: hash-key, [hash-key], or [hash-key range-key]
+
+  Update map is a map from attribute name to [action value], where
+  action is one of :add, :put, or :delete.
+
+  Takes the following options:
+    :expected - a map from attribute name to:
+       :rotary.client/exists - checks if the attribute exists
+       :rotary.client/not-exists - checks if the attribute doesn't exist
+       anything else - checks if the attribute is equal to it
+    :return-values - specify what to return:
+       \"NONE\", \"ALL_OLD\", \"UPDATED_OLD\", \"ALL_NEW\", \"UPDATED_NEW\""
+  [cred table key update-map & {:keys [expected return-values]}]
+  (letfn [(to-attr-value-update-map [x] [(first x) (to-attr-value-update (last x))])]
+    (let [attribute-update-map (into {} (map to-attr-value-update-map update-map))]
+      (.updateItem
+       (db-client cred)
+       (doto (UpdateItemRequest.)
+         (.setTableName table)
+         (.setKey (item-key key))
+         (.setAttributeUpdates attribute-update-map)
+         (.setExpected (to-expected-values expected))
+         (.setReturnValues return-values))))))
 
 (defn get-item
-  "Retrieve an item from a DynamoDB table by its hash key."
-  [cred table hash-key]
+  "Retrieve an item (a Clojure map) from a DynamoDB table by its key.
+
+  The key can be: hash-key, [hash-key], or [hash-key range-key]
+
+  Options can be:
+    :consistent - consistent read
+    :attributes-to-get - a list of attribute names to return
+
+  The metadata of the return value contains:
+    :consumed-capacity-units - the consumed capacity units"
+  [cred table key & {:keys [consistent attributes-to-get] :or {consistent false}}]
   (as-map
    (.getItem
     (db-client cred)
     (doto (GetItemRequest.)
       (.setTableName table)
-      (.setKey (item-key hash-key))))))
+      (.setKey (item-key key))
+      (.setConsistentRead consistent)
+      (.setAttributesToGet attributes-to-get)))))
 
 (defn delete-item
-  "Delete an item from a DynamoDB table by its hash key."
-  [cred table hash-key]
-  (.deleteItem
-   (db-client cred)
-   (DeleteItemRequest. table (item-key hash-key))))
+  "Delete an item from a DynamoDB table specified by its key, if the
+  coditions are met. Takes the following options:
+    :expected - a map from attribute name to:
+       :rotary.client/exists - checks if the attribute exists
+       :rotary.client/not-exists - checks if the attribute doesn't exist
+       anything else - checks if the attribute is equal to it
+    :return-values - specify what to return:
+       \"NONE\", \"ALL_OLD\", \"UPDATED_OLD\", \"ALL_NEW\", \"UPDATED_NEW\"
 
-(defn scan
-  "Return the items in a DynamoDB table."
-  [cred table]
-  (map item-map
-       (.getItems
-        (.scan
-         (db-client cred)
-         (ScanRequest. table)))))
+  The metadata of the return value contains:
+    :consumed-capacity-units - the consumed capacity units"
+  [cred table key & {:keys [expected return-values]}]
+  (as-map
+   (.deleteItem
+    (db-client cred)
+    (doto (DeleteItemRequest. table (item-key key))
+      (.setExpected (to-expected-values expected))
+      (.setReturnValues return-values)))))
 
-(defn- set-range-condition
-  "Add the range key condition to a QueryRequest object"
-  [query-request operator & [range-key range-end]]
-  (let [attribute-list (map (fn [arg] (to-attr-value arg)) (remove nil? [range-key range-end]))]
-    (.setRangeKeyCondition query-request
-                           (doto (Condition.)
-                             (.withComparisonOperator operator)
-                             (.withAttributeValueList attribute-list)))))
-
-(defn- normalize-operator [operator]
-  "Maps Clojure operators to DynamoDB operators"
-  (let [operator-map {:> "GT" :>= "GE" :< "LT" :<= "LE" := "EQ"}
-        op (->> operator name str/upper-case)]
-    (operator-map (keyword op) op)))
+(defn- build-condition
+  [operator & values]
+  (let [attribute-list (map to-attr-value (remove nil? values))]
+    (doto (Condition.)
+      (.withComparisonOperator (normalize-operator operator))
+      (.withAttributeValueList attribute-list))))
 
 (defn- query-request
   "Create a QueryRequest object."
-  [table hash-key range-clause {:keys [order limit count consistent]}]
+  [table hash-key range-clause {:keys [order limit count consistent attributes-to-get exclusive-start-key]}]
   (let [qr (QueryRequest. table (to-attr-value hash-key))
         [operator range-key range-end] range-clause]
     (when operator
-      (set-range-condition qr (normalize-operator operator) range-key range-end))
+      (.setRangeKeyCondition qr (build-condition operator range-key range-end)))
     (when order
       (.setScanIndexForward qr (not= order :desc)))
     (when limit
@@ -248,6 +359,10 @@
       (.setCount qr count))
     (when consistent
       (.setConsistentRead qr consistent))
+    (when attributes-to-get
+      (.setAttributesToGet qr attributes-to-get))
+    (when exclusive-start-key
+      (.setExclusiveStartKey qr (item-key exclusive-start-key)))
     qr))
 
 (defn query
@@ -257,10 +372,70 @@
     :order - may be :asc or :desc (defaults to :asc)
     :limit - should be a positive integer
     :count - return a count if logical true
-    :consistent - return a consistent read if logical true"
-  [cred table hash-key & [range-clause options]]
-  (map item-map
-       (.getItems
-        (.query
-         (db-client cred)
-         (query-request table hash-key range-clause options)))))
+    :consistent - return a consistent read if logical true
+    :attributes-to-get - a list of attribute names
+    :exclusive-start-key - primary key of the item from which to
+         continue an earlier query
+
+  The metadata of the return value contains:
+    :count - the number of items in the response
+    :consumed-capacity-units - the consumed capacity units
+    :last-evaluated-key - the primary key of the item where the query
+         operation stopped, or nil if the query is fully completed. It
+         can be used to continue the operation by supplying it as a
+         value to :exclusive-start-key"
+  [cred table hash-key range-clause & {:keys [order limit count consistent attributes-to-get exclusive-start-key] :as options}]
+  (let [query-result (.query
+                      (db-client cred)
+                      (query-request table hash-key range-clause options))
+        item-count   (.getCount query-result)]
+    (with-meta
+      (map item-map (or (.getItems query-result) {}))
+      (merge {:count item-count
+              :consumed-capacity-units (.getConsumedCapacityUnits query-result)}
+             (if-let [k (.getLastEvaluatedKey query-result)]
+               {:last-evaluated-key (decode-key k)})))))
+
+(defn- to-scan-filter
+  [scan-filter]
+  (when scan-filter
+    (fmap #(apply build-condition %) scan-filter)))
+
+(defn scan
+  "Return the items in a DynamoDB table.
+
+  The scan-filter is a map from attribute name to condition in the
+  form [op param1 param2 ...].
+
+  Takes the following options:
+    :limit - should be a positive integer
+    :count - return a count if logical true
+    :attributes-to-get - a list of attribute names
+    :exclusive-start-key - primary key of the item from which to
+         continue an earlier query
+
+  The metadata of the return value contains:
+    :count - the number of items in the response
+    :scanned-count - number of items in the complete scan before any
+         filters are applied
+    :consumed-capacity-units - the consumed capacity units
+    :last-evaluated-key - the primary key of the item where the scan
+         operation stopped, or nil if the scan is fully completed. It
+         can be used to continue the operation by supplying it as a
+         value to :exclusive-start-key"
+  [cred table scan-filter & {:keys [limit count attributes-to-get exclusive-start-key]}]
+  (let [result (.scan
+                (db-client cred)
+                (doto (ScanRequest. table)
+                  (.setScanFilter (to-scan-filter scan-filter))
+                  (.setLimit limit)
+                  (.setCount count)
+                  (.setAttributesToGet attributes-to-get)
+                  (.setExclusiveStartKey (item-key exclusive-start-key))))]
+    (with-meta
+      (map item-map (or (.getItems result) {}))
+      (merge {:count (.getCount result)
+              :scanned-count (.getScannedCount result)
+              :consumed-capacity-units (.getConsumedCapacityUnits result)}
+             (if-let [k (.getLastEvaluatedKey result)]
+               {:last-evaluated-key (decode-key k)})))))


### PR DESCRIPTION
This adds support for various functionality in Amazon's SDK that was not previously accessible. This includes specifying which attributes to get, desired return values, expected values for conditional reads/writes, and exclusive start key. Documentation has been expanded to describe the new options.

We also now support keys in several formats: `hash-key`, `[hash-key]`, or `[hash-key range-key]`

Thanks to @itoshkov who contributed many changes.
