### PR TITLE
Added proxy support

### DIFF
--- a/src/rotary/client.clj
+++ b/src/rotary/client.clj
@@ -40,17 +40,14 @@
 (defn- db-client*
   "Get a AmazonDynamoDBClient instance for the supplied credentials."
   [{:keys [access-key secret-key endpoint proxy-host proxy-port]}]
-  (let [aws-creds (BasicAWSCredentials. access-key secret-key)
-        client-configuration (when (and proxy-host proxy-port) (ClientConfiguration.))]
-    (when client-configuration
-      (doto client-configuration
+  (let [aws-creds     (BasicAWSCredentials. access-key secret-key)
+        client-config (ClientConfiguration.)]
+    (when (and proxy-host proxy-port)
+      (doto client-config
         (.setProxyHost proxy-host)
         (.setProxyPort proxy-port)))
-    (let [client (if client-configuration
-                   (AmazonDynamoDBClient. aws-creds client-configuration)
-                   (AmazonDynamoDBClient. aws-creds))]
-      (when endpoint
-        (.setEndpoint client endpoint))
+    (let [client (AmazonDynamoDBClient. aws-creds client-config)]
+      (when endpoint (.setEndpoint client endpoint))
       client)))
 
 (def db-client

--- a/src/rotary/client.clj
+++ b/src/rotary/client.clj
@@ -42,10 +42,8 @@
   [{:keys [access-key secret-key endpoint proxy-host proxy-port]}]
   (let [aws-creds     (BasicAWSCredentials. access-key secret-key)
         client-config (ClientConfiguration.)]
-    (when (and proxy-host proxy-port)
-      (doto client-config
-        (.setProxyHost proxy-host)
-        (.setProxyPort proxy-port)))
+    (when proxy-host (.setProxyHost client-config proxy-host))
+    (when proxy-port (.setProxyPort client-config proxy-port))
     (let [client (AmazonDynamoDBClient. aws-creds client-config)]
       (when endpoint (.setEndpoint client endpoint))
       client)))

--- a/src/rotary/client.clj
+++ b/src/rotary/client.clj
@@ -3,7 +3,8 @@
   (:use [clojure.algo.generic.functor :only (fmap)]
         [clojure.core.incubator :only (-?>>)])
   (:require [clojure.string :as str])
-  (:import com.amazonaws.auth.BasicAWSCredentials
+  (:import com.amazonaws.ClientConfiguration
+           com.amazonaws.auth.BasicAWSCredentials
            com.amazonaws.services.dynamodb.AmazonDynamoDBClient
            [com.amazonaws.services.dynamodb.model
             AttributeValue
@@ -38,12 +39,14 @@
 
 (defn- db-client*
   "Get a AmazonDynamoDBClient instance for the supplied credentials."
-  [cred]
-  (let [aws-creds (BasicAWSCredentials. (:access-key cred) (:secret-key cred))
-        client (AmazonDynamoDBClient. aws-creds)]
-    (when-let [endpoint (:endpoint cred)]
-      (.setEndpoint client endpoint))
-    client))
+  [{:keys [access-key secret-key endpoint proxy-host proxy-port]}]
+  (let [aws-creds     (BasicAWSCredentials. access-key secret-key)
+        client-config (ClientConfiguration.)]
+    (when proxy-host (.setProxyHost client-config proxy-host))
+    (when proxy-port (.setProxyPort client-config proxy-port))
+    (let [client (AmazonDynamoDBClient. aws-creds client-config)]
+      (when endpoint (.setEndpoint client endpoint))
+      client)))
 
 (def db-client
   (memoize db-client*))


### PR DESCRIPTION
I'm adding proxy support to the creation of the DynamoDB client. 

In the credential map two new keys :proxy-host and :proxy-port can be specified. If they exist, a ClientConfiguration instance is added to the constructor of the AmazonDynamoDB object. 

E.g.:

{:access-key "AAA" :secret-key "ZZZ" :proxy-host "proxy-us.intel.com" :proxy-port 911}
